### PR TITLE
Changed Check-order, so longlink is checked before shortlink.

### DIFF
--- a/node/app/controllers/link.server.controller.js
+++ b/node/app/controllers/link.server.controller.js
@@ -144,8 +144,8 @@ exports.findLongLink = function(req, res, next) {
         longLink: String,
         longURL: String
     };
-
-    if (GLOBAL_PREMIUM == false) {
+    console.log(link.shortlink);
+    if (GLOBAL_PREMIUM == false || link.shortlink=='') {
         Link.find({
                 "longlink": link.longlink
             },

--- a/node/app/routes/link.server.routes.js
+++ b/node/app/routes/link.server.routes.js
@@ -4,14 +4,14 @@ var bodyParser = require('body-parser')
 module.exports = function(app) {
     app.use(bodyParser.json()); // to support JSON-encoded bodies
 
-    app.route('/link').post(links.validateURL, links.checkShortLink, links.checkLongLink, links.findLongLink, links.create);
+    app.route('/link').post(links.validateURL, links.findLongLink, links.checkShortLink, links.checkLongLink, links.create);
 
     app.route('/qr/:slink').get(links.redirectQR);
 
     app.route('/all').get(links.list);
 
     app.route('/linktext').get(links.text).post(links.text);
-    
+
     //redirect
     app.route('/:slink').get(links.redirect);
 
@@ -20,4 +20,3 @@ module.exports = function(app) {
 
     app.param('slink', links.linkByShort);
 };
- 


### PR DESCRIPTION
When a Premium-user generates a new shorturl without giving the shortlink, the longlinkcheck will be run to ensure there are no duplicates in database.

Closes #44
