### PR TITLE
add unit tests

### DIFF
--- a/node/app/controllers/link.server.controller.js
+++ b/node/app/controllers/link.server.controller.js
@@ -25,7 +25,6 @@ var createLinkModel = function (link) {
 exports.createLinkModel = createLinkModel; 
 
 exports.create = function (req, res, next) {
-    console.log("create");
     var link = new Link(req.body);    
     var LinkSuccess = createLinkModel(link);  
     link.save(function (err) {
@@ -52,16 +51,10 @@ exports.list = function (req, res, next) {
     });
 };
 
-exports.text = function (req, res) {
-    console.log(req.body);
-};
 
 exports.redirect = function (req, res) {
     //Longlink has to save in standardformat to make this redirect correct
-    console.log("redi");
-
     var link = new Link(req.body);
-    console.log(link.shortlink);
     if (link != undefined) {
         statistic.updateStatistic(link.shortlink, false);
         res.redirect(link.longlink);
@@ -149,7 +142,6 @@ exports.findLongLink = function (req, res, next) {
         longLink: String,
         longURL: String
     };
-    console.log(link.shortlink);
     if (GLOBAL_PREMIUM == false || link.shortlink == '') {
         Link.find({
                 "longlink": link.longlink
@@ -283,3 +275,5 @@ function validateUrl(value) {
     var regex = new RegExp("^(http[s]?:\\/\\/){1}(www\\.)?([0-9A-Za-z-\\.@:%_\+~#=]+)+((\\.[a-zA-Z]{2,3})+)(/(.)*)?(\\?(.)*)?");
     return regex.test(value);
 }
+
+exports.validateUrl = validateUrl;

--- a/node/app/controllers/link.server.controller.js
+++ b/node/app/controllers/link.server.controller.js
@@ -260,7 +260,7 @@ exports.checkShortLink = function (req, res, next) {
     );
 };
 
-exports.randomText = function () {
+var randomText = function() {
     var text = "";
     var possible = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
 
@@ -271,9 +271,9 @@ exports.randomText = function () {
     return text;
 }
 
-function validateUrl(value) {
+var validateUrl = function(value) {
     var regex = new RegExp("^(http[s]?:\\/\\/){1}(www\\.)?([0-9A-Za-z-\\.@:%_\+~#=]+)+((\\.[a-zA-Z]{2,3})+)(/(.)*)?(\\?(.)*)?");
     return regex.test(value);
 }
-
+exports.randomText = randomText;
 exports.validateUrl = validateUrl;

--- a/node/app/routes/link.server.routes.js
+++ b/node/app/routes/link.server.routes.js
@@ -10,8 +10,6 @@ module.exports = function(app) {
 
     app.route('/all').get(links.list);
 
-    app.route('/linktext').get(links.text).post(links.text);
-
     //redirect
     app.route('/:slink').get(links.redirect);
 

--- a/node/test/index.server.controller.js
+++ b/node/test/index.server.controller.js
@@ -1,0 +1,19 @@
+var expect = require("chai").expect;
+var httpMocks = require('node-mocks-http');
+var index = require("../app/controllers/index.server.controller.js");
+
+describe("Index Controller", function () {
+    describe("Check title", function () {
+        it("checks the title of the index page", function () {
+            var req = httpMocks.createRequest({
+                body: {
+                    shortlink: 'abc',
+                    longlink: 'www.abc.de'
+                }
+            });
+            var res = httpMocks.createResponse();
+            index.render(req, res);
+            expect(res._getRenderData().title).to.equal('Home');
+        });
+    });
+});

--- a/node/test/link.server.controller.js
+++ b/node/test/link.server.controller.js
@@ -7,82 +7,171 @@ var httpMocks = require('node-mocks-http');
 var url = require("url");
 
 describe("Link Controller", function () {
-  describe("Random Text Generator", function () {
-    it("creates a 5 character random string", function () {
-      var rnd = link.randomText();
-      var rnd2 = link.randomText();
-      expect(rnd.length).to.equal(5);
-    });    
-  });
-});
-  describe("Create Link Model", function () {
-    it("creates an extended link model from shorter model", function () {
-      var mock = { shortlink: "abcde", longlink: "https://google.de"};
-      GLOBAL_SERVER = "localhost:3000";
-      var model = link.createLinkModel(mock);
-      expect(model.shortLink).to.equal("/abcde");
-      expect(model.shortURL).to.equal("localhost:3000/abcde");
-      expect(model.shortQR).to.equal("localhost:3000/qr/abcde");
-      expect(model.longURL).to.equal("https://google.de");
-      expect(model.longLink).to.equal("google.de");
-    });    
-  }); 
-    
-    describe("CheckLongLink test", function() {
-        it("Premium and Systemurl", function() {
-            var req = httpMocks.createRequest({body:{shortlink:'stats', longlink:'testt.de'}});
-            var res = httpMocks.createResponse();
-            GLOBAL_PREMIUM='true';
-            var re = link.checkLongLink(req, res, function() {
-                expect(res.error).to.equal(200); //gesetzt?
-            });            
+    describe("Random Text Generator", function () {
+        it("creates a 5 character random string", function () {
+            var rnd = link.randomText();
+            var rnd2 = link.randomText();
+            expect(rnd.length).to.equal(5);
         });
-    });   
-    describe("CheckLongLink test", function() {
-        it("Premium and no Systemurl", function() {
-            var req = httpMocks.createRequest({body:{shortlink:'abcd', longlink:'testt.de'}});
-            var res = httpMocks.createResponse();
-            GLOBAL_PREMIUM='true';
-            var re = link.checkLongLink(req, res, function() {
-                expect(res.statusCode).to.equal(200);
-            });
-            
-        });
-    });   
-    describe("CheckLongLink test", function() {
-        it("No Premium", function() {
-            var req = httpMocks.createRequest({body:{shortlink:'qweqe', longlink:'testt.de'}});
-            var res = httpMocks.createResponse();
-            GLOBAL_PREMIUM='false';
-            var re = link.checkLongLink(req, res, function() {
-                expect(res.statusCode).to.equal(200);
-            });
-            
-        });
-    });   
-    
-    describe("Link Controller", function () {
-        describe("Check Short Link", function () {
-            it("checks if shortlink already exists", function () {
-                GLOBAL_SERVER = 'localhost:8001';
-                GLOBAL_PREMIUM = true;
-                var req = httpMocks.createRequest({body: {shortlink: 'abc', longlink: 'www.abc.de'}});
-                var res = httpMocks.createResponse();
-                link.create(req, res);
-                link.checkShortLink(req, res);
-                expect(res.statusCode).to.equal(200);
-            });
+    });
+    describe("Create extended Link Model", function () {
+        it("creates an extended link model from shorter model", function () {
+            var mock = {
+                shortlink: "abcde",
+                longlink: "https://google.de"
+            };
+            GLOBAL_SERVER = "localhost:3000";
+            var model = link.createLinkModel(mock);
+            expect(model.shortLink).to.equal("/abcde");
+            expect(model.shortURL).to.equal("localhost:3000/abcde");
+            expect(model.shortQR).to.equal("localhost:3000/qr/abcde");
+            expect(model.longURL).to.equal("https://google.de");
+            expect(model.longLink).to.equal("google.de");
         });
     });
 
-describe("Link Controller", function () {
+    describe("Check Long Link", function () {
+        it("checks Long Link with Premium and Systemurl", function () {
+            var req = httpMocks.createRequest({
+                body: {
+                    shortlink: 'stats',
+                    longlink: 'testt.de'
+                }
+            });
+            var res = httpMocks.createResponse();
+            GLOBAL_PREMIUM = "true";
+            var re = link.checkLongLink(req, res, function () {
+                expect(res.error).to.equal(200); //gesetzt?
+            });
+        });
+    });
+    describe("Check Long Link", function () {
+        it("checks Long Link with Premium and no Systemurl", function () {
+            var req = httpMocks.createRequest({
+                body: {
+                    shortlink: 'abcd',
+                    longlink: 'testt.de'
+                }
+            });
+            var res = httpMocks.createResponse();
+            GLOBAL_PREMIUM = "true";
+            var re = link.checkLongLink(req, res, function () {
+                expect(res.statusCode).to.equal(200);
+            });
+
+        });
+    });
+    describe("Check Long Link", function () {
+        it("checks Long Link without Premium", function () {
+            var req = httpMocks.createRequest({
+                body: {
+                    shortlink: 'qweqe',
+                    longlink: 'testt.de'
+                }
+            });
+            var res = httpMocks.createResponse();
+            GLOBAL_PREMIUM = 'false';
+            var re = link.checkLongLink(req, res, function () {
+                expect(res.statusCode).to.equal(200);
+            });
+
+        });
+    });
+
+    describe("Check Short Link", function () {
+        it("checks if shortlink already exists", function () {
+            GLOBAL_SERVER = 'localhost:8001';
+            GLOBAL_PREMIUM = "true";
+            var req = httpMocks.createRequest({
+                body: {
+                    shortlink: 'abc',
+                    longlink: 'www.abc.de'
+                }
+            });
+            var res = httpMocks.createResponse();
+            link.create(req, res);
+            link.checkShortLink(req, res);
+            expect(res.statusCode).to.equal(200);
+        });
+    });
+
     describe("Check Short Link", function () {
         it("checks if shortlink is a new one", function () {
             GLOBAL_SERVER = 'localhost:8001';
-            GLOBAL_PREMIUM = true;
-            var req = httpMocks.createRequest({body: {shortlink: 'abc', longlink: 'www.abc.de'}});
+            GLOBAL_PREMIUM = "true";
+            var req = httpMocks.createRequest({
+                body: {
+                    shortlink: 'abc',
+                    longlink: 'www.abc.de'
+                }
+            });
             var res = httpMocks.createResponse();
             link.checkShortLink(req, res);
+            expect(res.statusCode).to.equal(200);
+        });
+    });
+    describe("URL Validation", function () {
+        it("checks valid Url 1/2", function () {
+            var test = link.validateUrl('https://www.google.de');
+            expect(test).to.equal(true);
+        });
+        it("checks valid Url 2/2", function () {
+            var test = link.validateUrl('http://www.google.de');
+            expect(test).to.equal(true);
+        });
+        it("checks valid Url 3/4", function () {
+            var test = link.validateUrl('https://google.de');
+            expect(test).to.equal(true);
+        });
+        it("checks valid Url 4/4", function () {
+            var test = link.validateUrl('http://google.de');
+            expect(test).to.equal(true);
+        });
+        it("checks invalid Url 1/4", function () {
+            var test = link.validateUrl('google.de');
+            expect(test).to.equal(false);
+        });
+        it("checks invalid Url 2/4", function () {
+            var test = link.validateUrl('www.google.de');
+            expect(test).to.equal(false);
+        });
+        it("checks invalid Url 3/4", function () {
+            var test = link.validateUrl('http://google');
+            expect(test).to.equal(false);
+        });
+        it("checks invalid Url 4/4", function () {
+            var test = link.validateUrl('ftp://google.de');
+            expect(test).to.equal(false);
+        });
+    });
+    describe("Application URL Check", function () {
+        it("checks if Short Link is an Application URL", function () {
+            var req = httpMocks.createRequest({
+                body: {
+                    shortlink: 'stats',
+                    longlink: 'www.abc.de',
+                    error: ''
+                }
+            });
+            GLOBAL_PREMIUM ="true";
+            var res = httpMocks.createResponse();
+            link.checkLongLink(req, res, function () {});
+            var data = JSON.parse(res._getData());
+            expect(data.error).to.equal('Shortlink stats is an application url');
+        });
+    });
+    describe("Find Shortlink", function () {
+        it("creates Short Link and checks if it was saved", function () {
+            GLOBAL_SERVER = 'localhost:8001';
+            var req = httpMocks.createRequest({
+                body: {
+                    shortlink: 'abcde',
+                    longlink: 'www.abcde.de'
+                }
+            });
+            var res = httpMocks.createResponse();
+            link.create(req, res);
+            link.linkByShort(req, res, function () {}, 'abcde');
             expect(res.statusCode).to.equal(200);
         });
     });


### PR DESCRIPTION
We still get a deprecation warning when executing "npm test" about mongoose promises.
[This](http://stackoverflow.com/questions/38138445/node3341-deprecationwarning-mongoose-mpromise/38153706) didn't solve it..
Maybe someone can take a look or we just ignore it? :thinking: 